### PR TITLE
Update GitHub Actions workflow to use 'nuxt generate' instead of 'nux…

### DIFF
--- a/.github/workflows/nuxtjs.yml
+++ b/.github/workflows/nuxtjs.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Build Nuxt app for GitHub Pages
         run: |
-          NUXT_APP_BASE_URL=/${{ github.event.repository.name }} npx nuxt build --preset github_pages
+          NUXT_APP_BASE_URL=/${{ github.event.repository.name }} npx nuxt generate --preset github_pages
 
       - name: Upload build output
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
…t build' for GitHub Pages deployment.